### PR TITLE
fix: #567 toolbar子类重写init导致未执行部分初始化

### DIFF
--- a/src/toolbars/Toolbar.js
+++ b/src/toolbars/Toolbar.js
@@ -44,12 +44,12 @@ export default class Toolbar {
     this.instanceId = this.$cherry.instanceId;
     this.menus = new HookCenter(this);
     this.drawMenus();
+    this.collectShortcutKey();
+    this.collectToolbarHandler();
     this.init();
   }
 
   init() {
-    this.collectShortcutKey();
-    this.collectToolbarHandler();
     Event.on(this.instanceId, Event.Events.cleanAllSubMenus, () => this.hideAllSubMenu());
   }
 


### PR DESCRIPTION
这个init函数看起来就是为子类部分重写初始化设置的
但collectToolbarHandler和collectShortcutKey两个函数，所以子类都应该执行
（处理快捷键时也只匹配toolbar的快捷键，不匹配子类的）
其他工具栏目前默认没有快捷键，所以未看到后者的bug，一起改掉了